### PR TITLE
PFORM-1305: Adding Get-FileHardLink function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+* Added `Get-FileHardLink` which is used to retrieve hard link targets.  This fixes a breaking change from Windows PowerShell where the `Target` property is not populated in PowerShell Core when using `Get-Item` to retrieve a previously linked file.

--- a/Carbon.FileSystem/Carbon.FileSystem.psd1
+++ b/Carbon.FileSystem/Carbon.FileSystem.psd1
@@ -18,7 +18,7 @@
     RootModule = 'Carbon.FileSystem.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.0.0'
+    ModuleVersion = '1.0.0'
 
     # ID used to uniquely identify this module
     GUID = ''
@@ -76,6 +76,7 @@
 
     # Functions to export from this module. Only list public function here.
     FunctionsToExport = @(
+        'Get-FileHardLink'
     )
 
     # Cmdlets to export from this module. By default, you get a script module, so there are no cmdlets.

--- a/Carbon.FileSystem/Carbon.FileSystem.psd1
+++ b/Carbon.FileSystem/Carbon.FileSystem.psd1
@@ -36,7 +36,9 @@
     Copyright = '(c) WebMD Health Services.'
 
     # Description of the functionality provided by this module
-    Description = ''
+    Description = 'The Carbon.FileSystem module currently only has one function, Get-FileHardLink, which is used to
+    retrieve hard link targets. This fixes a breaking change from Windows PowerShell where the Target property is
+    not populated in PowerShell Core when using Get-Item to retrieve a previously linked file.'
 
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.1'

--- a/Carbon.FileSystem/Carbon.FileSystem.psm1
+++ b/Carbon.FileSystem/Carbon.FileSystem.psm1
@@ -20,6 +20,37 @@ Set-StrictMode -Version 'Latest'
 # module in development has its functions in the Functions directory.
 $moduleRoot = $PSScriptRoot
 
+Add-Type @'
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Carbon.FileSystem
+{
+  public static class Kernel32
+  {
+
+    #region WinAPI P/Invoke declarations
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern IntPtr FindFirstFileNameW(string lpFileName, uint dwFlags, ref uint StringLength, StringBuilder LinkName);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool FindNextFileNameW(IntPtr hFindStream, ref uint StringLength, StringBuilder LinkName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool FindClose(IntPtr hFindFile);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool GetVolumePathName(string lpszFileName, [Out] StringBuilder lpszVolumePathName, uint cchBufferLength);
+
+    public static readonly IntPtr INVALID_HANDLE_VALUE = (IntPtr)(-1); // 0xffffffff;
+    public const int MAX_PATH = 65535; // Max. NTFS path length.
+    #endregion
+   }
+}
+'@
+
 # Store each of your module's functions in its own file in the Functions 
 # directory. On the build server, your module's functions will be appended to 
 # this file, so only dot-source files that exist on the file system. This allows

--- a/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
+++ b/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
@@ -1,0 +1,34 @@
+
+function Get-FileHardLink
+{
+    param(
+        [Parameter(Mandatory)]
+        [String] $Path
+    )
+
+    $sbPath = [Text.StringBuilder]::New([Carbon.FileSystem.Kernel32]::MAX_PATH)
+    $charCount = [uint]$sbPath.Capacity; # in/out character-count variable for the WinAPI calls.
+    # Get the volume (drive) part of the target file's full path (e.g., @"C:\")
+    [void][Carbon.FileSystem.Kernel32]::GetVolumePathName($Path, $sbPath, $charCount)
+    $volume = $sbPath.ToString();
+    # Trim the trailing "\" from the volume path, to enable simple concatenation
+    # with the volume-relative paths returned by the FindFirstFileNameW() and FindFirstFileNameW() functions,
+    # which have a leading "\"
+    $volume = $volume.Substring(0, $volume.Length - 1);
+    # Loop over and collect all hard links as their full paths.
+    [IntPtr]$findHandle = [IntPtr]::Zero
+    $findHandle = [Carbon.FileSystem.Kernel32]::FindFirstFileNameW($Path, 0, [ref]$charCount, $sbPath)
+    if( [Carbon.FileSystem.Kernel32]::INVALID_HANDLE_VALUE -eq $findHandle)
+    {
+        Write-Warning 'Invalid handle.'
+        return
+    }
+  
+    do
+    {
+        Join-Path -Path $volume -ChildPath $sbPath.ToString() | Write-Output # Add the full path to the result list.
+        $charCount = [uint]$sbPath.Capacity; # Prepare for the next FindNextFileNameW() call.
+    }
+    while( [Carbon.FileSystem.Kernel32]::FindNextFileNameW($findHandle, [ref]$charCount, $sbPath) )
+    [void][Carbon.FileSystem.Kernel32]::FindClose($findHandle);
+}

--- a/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
+++ b/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
@@ -6,6 +6,8 @@ Retrieves hard link targets from a file.
 Get-FileHardLink retrieves hard link targets from a file given a file path. This fixes compatibility issues between
 Windows PowerShell and PowerShell Core when retrieving targets from a hard link.
 
+The Path parameter is a full path to the file that you want to retrieve hard link targets from.
+
 .EXAMPLE
 Get-FileHardLink -Path $Path
 
@@ -43,7 +45,7 @@ function Get-FileHardLink
         {
             $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             $msg = "Failed to find hard links to path ""$($Path | Split-Path -Relative)"": the system error code is ""$($errorCode)""."
-            Write-Error $msg
+            Write-Error $msg -ErrorAction $ErrorActionPreference
             return
         }
   

--- a/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
+++ b/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
@@ -6,8 +6,6 @@ Retrieves hard link targets from a file.
 Get-FileHardLink retrieves hard link targets from a file given a file path. This fixes compatibility issues between
 Windows PowerShell and PowerShell Core when retrieving targets from a hard link.
 
-The Path parameter is a full path to the file that you want to retrieve hard link targets from.
-
 .EXAMPLE
 Get-FileHardLink -Path $Path
 
@@ -16,6 +14,7 @@ Demonstrates how to retrieve a hard link given a file path.
 function Get-FileHardLink
 {
     param(
+        # The path whose hard links to get/return. Must exist.
         [Parameter(Mandatory)]
         [String] $Path
     )
@@ -28,7 +27,8 @@ function Get-FileHardLink
         return
     }
 
-    try {
+    try 
+    {
         $sbPath = [Text.StringBuilder]::New([Carbon.FileSystem.Kernel32]::MAX_PATH)
         $charCount = [uint32]$sbPath.Capacity; # in/out character-count variable for the WinAPI calls.
         # Get the volume (drive) part of the target file's full path (e.g., @"C:\")
@@ -57,7 +57,8 @@ function Get-FileHardLink
         while( [Carbon.FileSystem.Kernel32]::FindNextFileNameW($findHandle, [ref]$charCount, $sbPath) )
         [void][Carbon.FileSystem.Kernel32]::FindClose($findHandle);
     }
-    catch {
-        Write-Error -Message $_
+    catch 
+    {
+        Write-Error -Message $_ -ErrorAction $ErrorActionPreference
     }
 }

--- a/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
+++ b/Carbon.FileSystem/Functions/Get-FileHardLink.ps1
@@ -26,31 +26,36 @@ function Get-FileHardLink
         return
     }
 
-    $sbPath = [Text.StringBuilder]::New([Carbon.FileSystem.Kernel32]::MAX_PATH)
-    $charCount = [uint]$sbPath.Capacity; # in/out character-count variable for the WinAPI calls.
-    # Get the volume (drive) part of the target file's full path (e.g., @"C:\")
-    [void][Carbon.FileSystem.Kernel32]::GetVolumePathName($Path, $sbPath, $charCount)
-    $volume = $sbPath.ToString();
-    # Trim the trailing "\" from the volume path, to enable simple concatenation
-    # with the volume-relative paths returned by the FindFirstFileNameW() and FindFirstFileNameW() functions,
-    # which have a leading "\"
-    $volume = $volume.Substring(0, $volume.Length - 1);
-    # Loop over and collect all hard links as their full paths.
-    [IntPtr]$findHandle = [IntPtr]::Zero
-    $findHandle = [Carbon.FileSystem.Kernel32]::FindFirstFileNameW($Path, 0, [ref]$charCount, $sbPath)
-    if( [Carbon.FileSystem.Kernel32]::INVALID_HANDLE_VALUE -eq $findHandle)
-    {
-        $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        $msg = "Failed to find hard links to path ""$($Path | Split-Path -Relative)"": the system error code is ""$($errorCode)""." 
-        Write-Error $msg
-        return
-    }
+    try {
+        $sbPath = [Text.StringBuilder]::New([Carbon.FileSystem.Kernel32]::MAX_PATH)
+        $charCount = [uint32]$sbPath.Capacity; # in/out character-count variable for the WinAPI calls.
+        # Get the volume (drive) part of the target file's full path (e.g., @"C:\")
+        [void][Carbon.FileSystem.Kernel32]::GetVolumePathName($Path, $sbPath, $charCount)
+        $volume = $sbPath.ToString();
+        # Trim the trailing "\" from the volume path, to enable simple concatenation
+        # with the volume-relative paths returned by the FindFirstFileNameW() and FindFirstFileNameW() functions,
+        # which have a leading "\"
+        $volume = $volume.Substring(0, $volume.Length - 1);
+        # Loop over and collect all hard links as their full paths.
+        [IntPtr]$findHandle = [IntPtr]::Zero
+        $findHandle = [Carbon.FileSystem.Kernel32]::FindFirstFileNameW($Path, 0, [ref]$charCount, $sbPath)
+        if( [Carbon.FileSystem.Kernel32]::INVALID_HANDLE_VALUE -eq $findHandle)
+        {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            $msg = "Failed to find hard links to path ""$($Path | Split-Path -Relative)"": the system error code is ""$($errorCode)""."
+            Write-Error $msg
+            return
+        }
   
-    do
-    {
-        Join-Path -Path $volume -ChildPath $sbPath.ToString() | Write-Output # Add the full path to the result list.
-        $charCount = [uint]$sbPath.Capacity; # Prepare for the next FindNextFileNameW() call.
+        do
+        {
+            Join-Path -Path $volume -ChildPath $sbPath.ToString() | Write-Output # Add the full path to the result list.
+            $charCount = [uint32]$sbPath.Capacity; # Prepare for the next FindNextFileNameW() call.
+        }
+        while( [Carbon.FileSystem.Kernel32]::FindNextFileNameW($findHandle, [ref]$charCount, $sbPath) )
+        [void][Carbon.FileSystem.Kernel32]::FindClose($findHandle);
     }
-    while( [Carbon.FileSystem.Kernel32]::FindNextFileNameW($findHandle, [ref]$charCount, $sbPath) )
-    [void][Carbon.FileSystem.Kernel32]::FindClose($findHandle);
+    catch {
+        Write-Error -Message $_
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-The "Carbon.FileSystem" module...
+The "Carbon.FileSystem" module currently only has one function `Get-FileHardLink` which is used to retrieve hard link targets.  This fixes a breaking change from Windows PowerShell where the `Target` property is not populated in PowerShell Core when using `Get-Item` to retrieve a previously linked file.
 
 # System Requirements
 

--- a/Tests/Carbon.FileSystem.Tests.ps1
+++ b/Tests/Carbon.FileSystem.Tests.ps1
@@ -68,12 +68,12 @@ BeforeAll {
     }
 }
 
-Describe 'Cabon.FileSystem.Tests' {
+Describe 'Cabon.FileSystem' {
     BeforeEach {
         Init
     }
 
-    It 'should have one' {
+    It 'should have about help topic' {
         GivenModuleImported
         ThenHelpTopic 'about_Carbon.FileSystem' -Exists
     }

--- a/Tests/Carbon.FileSystem.Tests.ps1
+++ b/Tests/Carbon.FileSystem.Tests.ps1
@@ -3,88 +3,87 @@
 #Requires -Version 5.1
 Set-StrictMode -Version 'Latest'
 
-& (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
 
-function GivenModuleImported
-{
-    # Don't do anything since Initialize-Test.ps1 imports the module.
-}
-
-function Init
-{
-}
-
-function ThenUseApprovedVerbs
-{
-    param(
-    )
-
-    $verbs = 
-        Get-Command -Module 'WhsAutomation'| 
-        Where-Object { $_ -isnot [Management.Automation.AliasInfo] } |
-        Select-Object -ExpandProperty Verb | 
-        Select-Object -Unique
-    if( $verbs )
+    function GivenModuleImported
     {
-        $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
-        $verbs | Should -BeIn $approvedVerbs
+        # Don't do anything since Initialize-Test.ps1 imports the module.
+    }
+    
+    function Init
+    {
+    }
+    
+    function ThenUseApprovedVerbs
+    {
+        param(
+        )
+    
+        $verbs = 
+            Get-Command -Module 'WhsAutomation'| 
+            Where-Object { $_ -isnot [Management.Automation.AliasInfo] } |
+            Select-Object -ExpandProperty Verb | 
+            Select-Object -Unique
+        if( $verbs )
+        {
+            $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
+            $verbs | Should -BeIn $approvedVerbs
+        }
+    }
+    
+    function ThenHelpTopic
+    {
+        param(
+            [Parameter(Mandatory,Position=0)]
+            [String]$Named,
+    
+            [Parameter(Mandatory)]
+            [switch]$Exists,
+    
+            [switch]$HasSynopsis,
+    
+            [switch]$HasDescription,
+    
+            [switch]$HasExamples
+        )
+    
+        $help = Get-Help -Name $Named -Full
+        $help | Should -Not -BeNullOrEmpty
+    
+        if( $HasSynopsis )
+        {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+    
+        if( $HasDescription )
+        {
+            $help.Description | Should -Not -BeNullOrEmpty
+        }
+    
+        if( $HasExamples )
+        {
+            $help.Examples | Should -Not -BeNullOrEmpty
+        }
     }
 }
 
-function ThenHelpTopic
-{
-    param(
-        [Parameter(Mandatory,Position=0)]
-        [String]$Named,
-
-        [Parameter(Mandatory)]
-        [switch]$Exists,
-
-        [switch]$HasSynopsis,
-
-        [switch]$HasDescription,
-
-        [switch]$HasExamples
-    )
-
-    $help = Get-Help -Name $Named -Full
-    $help | Should -Not -BeNullOrEmpty
-
-    if( $HasSynopsis )
-    {
-        $help.Synopsis | Should -Not -BeNullOrEmpty
-    }
-
-    if( $HasDescription )
-    {
-        $help.Description | Should -Not -BeNullOrEmpty
-    }
-
-    if( $HasExamples )
-    {
-        $help.Examples | Should -Not -BeNullOrEmpty
-    }
-}
-
-Describe ('Carbon.FileSystem.help topic') {
-    It 'should have one' {
+Describe 'Cabon.FileSystem.Tests' {
+    BeforeEach {
         Init
+    }
+
+    It 'should have one' {
         GivenModuleImported
         ThenHelpTopic 'about_Carbon.FileSystem' -Exists
     }
-}
 
-Describe ('Carbon.FileSystem.command verbs') {
     It 'should only use approved verbs' {
-        Init
         GivenModuleImported
         ThenUseApprovedVerbs
     }
-}
 
-Describe ('Carbon.FileSystem.command help topics') {
     It 'should have a help topic for each command' {
-        Init
         GivenModuleImported
         foreach( $cmd in (Get-Command -Module 'Carbon.FileSystem' -CommandType Function,Cmdlet,Filter))
         {

--- a/Tests/Get-FileHardLink.Tests.ps1
+++ b/Tests/Get-FileHardLink.Tests.ps1
@@ -58,6 +58,10 @@ BeforeAll {
 
         if( $In )
         {
+            $Path = Join-Path -Path $In -ChildPath $Path
+        }
+        else 
+        {
             $Path = Join-Path -Path $testRoot -ChildPath $Path
         }
 

--- a/Tests/Get-FileHardLink.Tests.ps1
+++ b/Tests/Get-FileHardLink.Tests.ps1
@@ -45,22 +45,6 @@ BeforeAll {
                     Remove-Item -Path $linkPath
                 }
 
-                if( Test-Path -Path $linkPath -PathType Leaf )
-                {
-                    $link = Get-Item -Path $linkPath
-                    if( -not $link.Target )
-                    {
-                        Write-Error -Message ('File "{0}" exists but is not a hardlink to "{1}". Remove this file, or use the -Force switch to delete it and re-create.' -f $linkPath, $targetPath) -ErrorAction $ErrorActionPreference
-                        return
-                    }
-
-                    if( $link.Target -notcontains $targetPath )
-                    {
-                        Write-Verbose ('Removing "{0}": exists but links to "{1}".' -f $linkPath,($link.Target -join '", "'))
-                        Remove-Item -Path $linkPath
-                    }
-                }
-
                 if( -not (Test-Path -Path $linkPath -PathType Leaf) )
                 {
                     Write-Verbose ('Creating hardlink "{0}" -> "{1}".' -f $linkPath,$targetPath)
@@ -125,7 +109,7 @@ BeforeAll {
 
         if( $PSBoundParameters.ContainsKey('HasLinkType') )
         {
-            Get-Item -Path $fullPath | Select-Object -Expand 'LinkType' | Should -Not:$Not -Be $HasLinkType
+            Get-Item -Path $fullPath -Force | Select-Object -Expand 'LinkType' | Should -Not:$Not -Be $HasLinkType
         }
 
         if( $PSBoundParameters.ContainsKey('Targets') )

--- a/Tests/Get-FileHardLink.Tests.ps1
+++ b/Tests/Get-FileHardLink.Tests.ps1
@@ -1,0 +1,169 @@
+
+#Requires -Version 5.1
+Set-StrictMode -Version 'Latest'
+
+BeforeAll {
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+
+    $script:testRoot = $null
+    $script:testNum = 0
+
+    function CreateHardlink
+    {
+        param(
+            [Parameter(Mandatory)]
+            [String] $RepoRoot,
+
+            [Parameter(Mandatory)]
+            [String] $Driver
+        )
+
+        if( -not (Test-Path -Path $RepoRoot -PathType Container) )
+        {
+            Write-Error -Message ('Repository root "{0}" does not exist.' -f $RepoRoot) -ErrorAction $ErrorActionPreference
+            return
+        }
+
+        Push-Location -Path $RepoRoot
+
+        try
+        {
+            $linkPath = Join-Path -Path '.' -ChildPath '.kitchen.local.yml'
+            $targetPath = Join-Path -Path '.' -ChildPath ('.kitchen.{0}.yml' -f $Driver)
+            if( -not (Test-Path -Path $targetPath -PathType Leaf) )
+            {
+                Write-Error -Message ('Target driver file "{0}" does not exist,' -f $targetPath) -ErrorAction $ErrorActionPreference
+                return
+            }
+
+            $targetPath = Resolve-Path -Path $targetPath | Select-Object -ExpandProperty 'ProviderPath'
+
+            if( (Test-Path -Path $linkPath -PathType Leaf) )
+            {
+                Write-Verbose -Message ('Removing "{0}": this file exists.' -f $linkPath)
+                Remove-Item -Path $linkPath
+            }
+
+            if( Test-Path -Path $linkPath -PathType Leaf )
+            {
+                $link = Get-Item -Path $linkPath
+                if( -not $link.Target )
+                {
+                    Write-Error -Message ('File "{0}" exists but is not a hardlink to "{1}". Remove this file, or use the -Force switch to delete it and re-create.' -f $linkPath, $targetPath) -ErrorAction $ErrorActionPreference
+                    return
+                }
+
+                if( $link.Target -notcontains $targetPath )
+                {
+                    Write-Verbose ('Removing "{0}": exists but links to "{1}".' -f $linkPath,($link.Target -join '", "'))
+                    Remove-Item -Path $linkPath
+                }
+            }
+
+            if( -not (Test-Path -Path $linkPath -PathType Leaf) )
+            {
+                Write-Verbose ('Creating hardlink "{0}" -> "{1}".' -f $linkPath,$targetPath)
+                New-Item -ItemType HardLink -Path $linkPath -Value $targetPath
+            }
+        }
+        finally
+        {
+            Pop-Location
+        }
+    }
+
+    function GivenFile
+    {
+        param(
+            [Parameter(Mandatory)]
+            [String] $Path,
+
+            [String] $In
+        )
+
+        if( $In )
+        {
+            $Path = Join-Path -Path $In -ChildPath $Path
+        }
+
+        New-Item -Path $Path -ItemType 'File'
+    }
+
+    function ThenFailed
+    {
+        param(
+            [Parameter(Mandatory)]
+            [string] $WithErrorMatching
+        )
+
+        $Global:Error[-1] | Should -Match $WithErrorMatching
+    }
+
+    function ThenFile
+    {
+        param(
+            [Parameter(Mandatory)]
+            [String]$Path,
+
+            [switch]$Not,
+
+            [switch]$Exists,
+
+            [String]$In,
+
+            [Object]$HasLinkType,
+
+            [Object]$Targets
+        )
+
+        $fullPath = $Path
+        if( $In )
+        {
+            $fullPath = Join-Path -Path $In -ChildPath $Path
+        }
+
+        if( $Exists )
+        {
+            $fullPath | Should -Not:$Not -Exist
+        }
+
+        if( $PSBoundParameters.ContainsKey('HasLinkType') )
+        {
+            Get-Item -Path $fullPath | Select-Object -Expand 'LinkType' | Should -Not:$Not -Be $HasLinkType
+        }
+
+        if( $PSBoundParameters.ContainsKey('Targets') )
+        {
+            if( $In -and $Targets -and -not [IO.Path]::IsPathRooted($Targets) )
+            {
+                $Targets = Join-Path -Path $In -ChildPath $Targets -Resolve
+            }
+            Get-FileHardLink -Path $fullPath | Should -Not:$Not -Contain $Targets
+        }
+    }
+}
+
+Describe 'Get-FileHardLink' {
+    BeforeEach { 
+        $script:testRoot = $null
+        $script:failed = $false
+        $script:testRoot = Join-Path -Path $TestDrive -ChildPath ($script:testNum++)
+        New-Item -Path $script:testRoot -ItemType 'Directory'
+        $Global:Error.Clear()
+    }
+
+    It 'should fail when there is no driver file' {
+        CreateHardlink -RepoRoot $testRoot -Driver 'testDriver' -ErrorAction SilentlyContinue
+        ThenFailed -WithErrorMatching '\.kitchen\.testDriver\.yml" does not exist'
+        ThenFile '.kitchen.local.yml' -Not -Exists -In $testRoot
+    }
+
+    It 'should retrieve targets from link when there is a driver file' {
+        GivenFile '.kitchen.somedriver.yml' -In $testRoot
+        CreateHardlink -RepoRoot $testRoot -Driver 'somedriver'
+        ThenFile '.kitchen.local.yml' -Exists `
+                                      -In $testRoot `
+                                      -HasLinkType 'HardLink' `
+                                      -Targets '.kitchen.somedriver.yml'
+    }
+}

--- a/Tests/Get-FileHardLink.Tests.ps1
+++ b/Tests/Get-FileHardLink.Tests.ps1
@@ -123,8 +123,8 @@ Describe 'Get-FileHardLink' {
         GivenHardlink -LinkPath $linkPath -ThatTargets 'testTarget.txt'
         ThenFile 'testTarget.txt' -Exists
         ThenFile 'link.txt' -Exists `
-                                    -HasLinkType 'HardLink' `
-                                    -Targets 'testTarget.txt'
+                            -HasLinkType 'HardLink' `
+                            -Targets 'testTarget.txt'
     }
 
     It 'should retrieve hard link targets when there are multiple link paths' {
@@ -134,10 +134,10 @@ Describe 'Get-FileHardLink' {
         GivenFile 'testTarget.txt'
         GivenHardlink -LinkPath $linkPath -ThatTargets 'testTarget.txt'
         ThenFile 'link1.txt' -Exists `
-                                    -HasLinkType 'HardLink' `
-                                    -Targets 'testTarget.txt'
+                             -HasLinkType 'HardLink' `
+                             -Targets 'testTarget.txt'
         ThenFile 'link2.txt' -Exists `
-                                    -HasLinkType 'HardLink' `
-                                    -Targets 'testTarget.txt'
+                             -HasLinkType 'HardLink' `
+                             -Targets 'testTarget.txt'
     }
 }

--- a/Tests/Import-Carbon.FileSystem.Tests.ps1
+++ b/Tests/Import-Carbon.FileSystem.Tests.ps1
@@ -2,50 +2,52 @@
 #Requires -Version 5.1
 Set-StrictMode -Version 'Latest'
 
-& (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
+BeforeAll{
+    & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Test.ps1' -Resolve)
 
-function GivenModuleLoaded
-{
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\Carbon.FileSystem\Carbon.FileSystem.psd1' -Resolve)
-    Get-Module -Name 'Carbon.FileSystem' | Add-Member -MemberType NoteProperty -Name 'NotReloaded' -Value $true
+    function GivenModuleLoaded
+    {
+        Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\Carbon.FileSystem\Carbon.FileSystem.psd1' -Resolve)
+        Get-Module -Name 'Carbon.FileSystem' | Add-Member -MemberType NoteProperty -Name 'NotReloaded' -Value $true
+    }
+    
+    function GivenModuleNotLoaded
+    {
+        Remove-Module -Name 'Carbon.FileSystem' -Force -ErrorAction Ignore
+    }
+    
+    function Init
+    {
+    
+    }
+    
+    function ThenModuleLoaded
+    {
+        $module = Get-Module -Name 'Carbon.FileSystem'
+        $module | Should -Not -BeNullOrEmpty
+        $module | Get-Member -Name 'NotReloaded' | Should -BeNullOrEmpty
+    }
+    
+    function WhenImporting
+    {
+        $script:importedAt = Get-Date
+        Start-Sleep -Milliseconds 1
+        & (Join-Path -Path $PSScriptRoot -ChildPath '..\Carbon.FileSystem\Import-Carbon.FileSystem.ps1' -Resolve)
+    }
 }
 
-function GivenModuleNotLoaded
-{
-    Remove-Module -Name 'Carbon.FileSystem' -Force -ErrorAction Ignore
-}
-
-function Init
-{
-
-}
-
-function ThenModuleLoaded
-{
-    $module = Get-Module -Name 'Carbon.FileSystem'
-    $module | Should -Not -BeNullOrEmpty
-    $module | Get-Member -Name 'NotReloaded' | Should -BeNullOrEmpty
-}
-
-function WhenImporting
-{
-    $script:importedAt = Get-Date
-    Start-Sleep -Milliseconds 1
-    & (Join-Path -Path $PSScriptRoot -ChildPath '..\Carbon.FileSystem\Import-Carbon.FileSystem.ps1' -Resolve)
-}
-
-Describe 'Import-Carbon.FileSystem.when module not loaded' {
-    It 'should import the module' {
+Describe 'Import-Carbon.FileSystem' {
+    BeforeEach {
         Init
+    }
+
+    It 'should import the module' {
         GivenModuleNotLoaded
         WhenImporting
         ThenModuleLoaded
     }
-}
 
-Describe 'Import-Carbon.FileSystem.when module loaded' {
     It 'should re-import the module' {
-        Init
         GivenModuleLoaded
         WhenImporting
         ThenModuleLoaded

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,6 @@ environment:
     job_group: pwsh
     appveyor_build_worker_image: Visual Studio 2022
 
-  - job_name: PowerShell 7.1 on macOS
-    job_group: pwsh
-    appveyor_build_worker_image: macOS
-
   - job_name: Windows PowerShell 5.1/.NET 4.6.2
     job_group: ps
     appveyor_build_worker_image: Visual Studio 2013
@@ -31,10 +27,6 @@ environment:
   - job_name: PowerShell 6.2 on Windows
     job_group: pwsh
     appveyor_build_worker_image: Visual Studio 2015
-
-  - job_name: PowerShell 7.2 on Ubuntu
-    job_group: pwsh
-    appveyor_build_worker_image: Ubuntu
 
   - job_name: PowerShell 7.1 on Windows
     job_group: pwsh


### PR DESCRIPTION
Added `Get-FileHardLink` which is used to retrieve hard link targets.  This fixes a breaking change from Windows PowerShell where the `Target` property is not populated in PowerShell Core when using `Get-Item` to retrieve a previously linked file.